### PR TITLE
refactor: Change class names to avoid using namespace aliases

### DIFF
--- a/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark0001TwoSum.cs
+++ b/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark0001TwoSum.cs
@@ -4,7 +4,7 @@ using LeetSharp.Solutions.Library.Implementations.Problem0001TwoSum;
 namespace LeetSharp.Benchmarks.Console.Benchmarks;
 
 [MemoryDiagnoser]
-public class Problem0001TwoSum
+public class Benchmark0001TwoSum
 {
     private readonly Random _random = new();
     private readonly BruteForce _bruteForce = new();

--- a/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark0013RomanToInteger.cs
+++ b/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark0013RomanToInteger.cs
@@ -1,12 +1,12 @@
 using BenchmarkDotNet.Attributes;
-using Solution = LeetSharp.Solutions.Library.Implementations.Problem0013RomanToInteger;
+using LeetSharp.Solutions.Library.Implementations;
 
 namespace LeetSharp.Benchmarks.Console.Benchmarks;
 
 [MemoryDiagnoser]
-public class Problem0013RomanToInteger
+public class Benchmark0013RomanToInteger
 {
-    private readonly Solution _problem0013RomanToInteger = new();
+    private readonly Problem0013RomanToInteger _problem0013RomanToInteger = new();
 
     // Uncomment the data set to run the benchmark against.
     public IEnumerable<string> Data()

--- a/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark0020ValidParentheses.cs
+++ b/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark0020ValidParentheses.cs
@@ -1,12 +1,12 @@
 using BenchmarkDotNet.Attributes;
-using Solution = LeetSharp.Solutions.Library.Implementations.Problem0020ValidParentheses;
+using LeetSharp.Solutions.Library.Implementations;
 
 namespace LeetSharp.Benchmarks.Console.Benchmarks;
 
 [MemoryDiagnoser]
-public class Problem0020ValidParentheses
+public class Benchmark0020ValidParentheses
 {
-    private readonly Solution _problem0020ValidParentheses = new();
+    private readonly Problem0020ValidParentheses _problem0020ValidParentheses = new();
 
     // Uncomment the data set to run the benchmark against.
     public IEnumerable<string> Data()

--- a/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark2235AddTwoIntegers.cs
+++ b/src/LeetSharp.Benchmarks.Console/Benchmarks/Benchmark2235AddTwoIntegers.cs
@@ -1,12 +1,12 @@
 using BenchmarkDotNet.Attributes;
-using Solution = LeetSharp.Solutions.Library.Implementations.Problem2235AddTwoIntegers;
+using LeetSharp.Solutions.Library.Implementations;
 
 namespace LeetSharp.Benchmarks.Console.Benchmarks;
 
 [MemoryDiagnoser]
-public class Problem2235AddTwoIntegers
+public class Benchmark2235AddTwoIntegers
 {
-    private readonly Solution _problem2235AddTwoIntegers = new();
+    private readonly Problem2235AddTwoIntegers _problem2235AddTwoIntegers = new();
 
     // Uncomment the data set to run the benchmark against.
     public IEnumerable<object[]> Data()

--- a/src/LeetSharp.Benchmarks.Console/Program.cs
+++ b/src/LeetSharp.Benchmarks.Console/Program.cs
@@ -2,4 +2,4 @@
 using LeetSharp.Benchmarks.Console.Benchmarks;
 
 // Select the benchmark to run within the <>.
-var summary = BenchmarkRunner.Run<Problem0001TwoSum>();
+var summary = BenchmarkRunner.Run<Benchmark0001TwoSum>();

--- a/test/LeetSharp.Solutions.Library.UnitTest/Test0001TwoSum.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test0001TwoSum.cs
@@ -3,7 +3,7 @@ using LeetSharp.Solutions.Library.Interfaces;
 
 namespace LeetSharp.Solutions.Library.UnitTest;
 
-public class Problem0001TwoSum
+public class Test0001TwoSum
 {
     [Theory]
     [InlineData(new[] { 2, 7, 11, 15 }, 9, new[] { 0, 1 })]

--- a/test/LeetSharp.Solutions.Library.UnitTest/Test0013RomanToInteger.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test0013RomanToInteger.cs
@@ -1,9 +1,9 @@
+using LeetSharp.Solutions.Library.Implementations;
 using LeetSharp.Solutions.Library.Interfaces;
-using Solution = LeetSharp.Solutions.Library.Implementations.Problem0013RomanToInteger;
 
 namespace LeetSharp.Solutions.Library.UnitTest;
 
-public class Problem0013RomanToInteger
+public class Test0013RomanToInteger
 {
     [Theory]
     [InlineData("III", 3)]
@@ -12,7 +12,7 @@ public class Problem0013RomanToInteger
     public void RomanToInteger_ReturnsTarget(string s, int expected)
     {
         // Arrange.
-        IProblem0013RomanToInteger sut = new Solution();
+        IProblem0013RomanToInteger sut = new Problem0013RomanToInteger();
 
         // Act.
         var actual = sut.RomanToInt(s);

--- a/test/LeetSharp.Solutions.Library.UnitTest/Test0020ValidParentheses.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test0020ValidParentheses.cs
@@ -3,7 +3,7 @@ using Solution = LeetSharp.Solutions.Library.Implementations.Problem0020ValidPar
 
 namespace LeetSharp.Solutions.Library.UnitTest;
 
-public class Problem0020ValidParentheses
+public class Test0020ValidParentheses
 {
     [Theory]
     [InlineData("()", true)]

--- a/test/LeetSharp.Solutions.Library.UnitTest/Test2235AddTwoIntegers.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test2235AddTwoIntegers.cs
@@ -3,7 +3,7 @@ using Solution = LeetSharp.Solutions.Library.Implementations.Problem2235AddTwoIn
 
 namespace LeetSharp.Solutions.Library.UnitTest;
 
-public class Problem2235AddTwoIntegers
+public class Test2235AddTwoIntegers
 {
     [Theory]
     [InlineData(12, 5, 17)]


### PR DESCRIPTION
It changes class names and files to avoid using namespace aliases like `using NewClassName = Namespace.ClassName`.