### PR TITLE
refactor: Test method names should match solution method names

### DIFF
--- a/test/LeetSharp.Solutions.Library.UnitTest/Test0013RomanToInteger.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test0013RomanToInteger.cs
@@ -8,6 +8,6 @@ public class Test0013RomanToInteger
     [InlineData("III", 3)]
     [InlineData("LVIII", 58)]
     [InlineData("MCMXCIV", 1994)]
-    public void RomanToInteger_ReturnsTarget(string s, int expected) =>
+    public void RomanToInt_ReturnsTarget(string s, int expected) =>
         Assert.Equal(expected, RomanToInt(s));
 }

--- a/test/LeetSharp.Solutions.Library.UnitTest/Test0020ValidParentheses.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test0020ValidParentheses.cs
@@ -12,6 +12,6 @@ public class Test0020ValidParentheses
     [InlineData("]", false)]
     [InlineData("){", false)]
     [InlineData("(])", false)]
-    public void ValidParentheses_ReturnsTarget(string s, bool expected) =>
+    public void IsValid_ReturnsTarget(string s, bool expected) =>
         Assert.Equal(expected, IsValid(s));
 }

--- a/test/LeetSharp.Solutions.Library.UnitTest/Test2235AddTwoIntegers.cs
+++ b/test/LeetSharp.Solutions.Library.UnitTest/Test2235AddTwoIntegers.cs
@@ -7,6 +7,6 @@ public class Test2235AddTwoIntegers
     [Theory]
     [InlineData(12, 5, 17)]
     [InlineData(-10, 4, -6)]
-    public void AddTwoIntegers_ReturnsTarget(int num1, int num2, int expected) =>
+    public void Sum_ReturnsTarget(int num1, int num2, int expected) =>
         Assert.Equal(expected, Sum(num1, num2));
 }


### PR DESCRIPTION
It refactors test method names to match solution method names instead of solution class names.